### PR TITLE
fixed font override on mapbox popup

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -25,3 +25,8 @@
 .mapboxgl-ctrl button.mapboxgl-ctrl-geolocate .mapboxgl-ctrl-icon {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='29' height='29' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg' fill='%23333'%3E%3Cpath d='M10 4C9 4 9 5 9 5v.1A5 5 0 0 0 5.1 9H5s-1 0-1 1 1 1 1 1h.1A5 5 0 0 0 9 14.9v.1s0 1 1 1 1-1 1-1v-.1a5 5 0 0 0 3.9-3.9h.1s1 0 1-1-1-1-1-1h-.1A5 5 0 0 0 11 5.1V5s0-1-1-1zm0 2.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 1 1 0-7z'/%3E%3Ccircle id='dot' cx='10' cy='10' r='2'/%3E%3Cpath id='stroke' d='M14 5l1 1-9 9-1-1 9-9z' display='none'/%3E%3C/svg%3E");
 }
+
+/* Mapbox Font Override */
+.mapboxgl-map {
+  font-family: inherit;
+}


### PR DESCRIPTION
# Description
​
Overrided mapbox default display font.
​
Fixes #44  (issue)
​
## Type of change
​
- [X] Bug fix (non-breaking change which fixes an issue)
​
# How Has This Been Tested?
​
<img width="392" alt="Screenshot 2023-03-23 at 11 11 32 AM" src="https://user-images.githubusercontent.com/105141510/227092278-8fe579ba-18a8-49f2-9eeb-f2f4f288474f.png">

- [ ] Screenshot A
- [ ] Screenshot B
​
# Checklist:
​
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
