### PR TITLE
Use REST convention and replace me endpoint with generic businesses/:id

### DIFF
--- a/app/controllers/biz/businesses_controller.rb
+++ b/app/controllers/biz/businesses_controller.rb
@@ -3,15 +3,15 @@ class Biz::BusinessesController < BizController
     @business = Business.new
   end
 
-  def me
-    @business = current_user.business
+  def show
+    @business = Business.find(params[:id])
   end
 
   def create
     @business = Business.new(business_params)
     @business.user_id = current_user.id
     if @business.save
-      redirect_to biz_me_path
+      redirect_to biz_business_path(@business)
     else
       render :new
     end

--- a/app/controllers/biz_controller.rb
+++ b/app/controllers/biz_controller.rb
@@ -4,7 +4,8 @@ class BizController < ApplicationController
   def validate_business
     if current_user&.account_type == "business" && current_user.business.nil? && (request.path != "/biz/businesses/new" && request.path != "/biz/businesses")
       redirect_to new_biz_business_path
+    elsif current_user&.account_type != "business"
+      redirect_to root_path
     end
-    redirect_to root_path if current_user&.account_type != "business"
   end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -2,6 +2,12 @@ class UserController < ApplicationController
   before_action :redirect_if_business_account
 
   def redirect_if_business_account
-    redirect_to biz_me_path if current_user&.account_type == "business"
+    return unless current_user&.account_type == "business"
+
+    if current_user.business.nil?
+      redirect_to new_biz_business_path
+    else
+      redirect_to biz_business_path(current_user.business.id)
+    end
   end
 end

--- a/app/views/biz/businesses/me.html.erb
+++ b/app/views/biz/businesses/me.html.erb
@@ -1,1 +1,0 @@
-<%= @business.to_json  %>

--- a/app/views/biz/businesses/show.html.erb
+++ b/app/views/biz/businesses/show.html.erb
@@ -1,0 +1,62 @@
+<div class="banner" style="background-image: url(<%= cl_image_path @business.user.banner.key %>)">
+  <div class="wrapper">
+    <div class="avatar-wrapper">
+      <%= cl_image_tag @business.user.photo.key, class: "avatar-user" %>
+    </div>
+  </div>
+</div>
+<div class="banner-seperator">
+</div>
+<div class="wrapper border-bottom mb-4">
+  <div>
+    <p class="fs-2 fw-bold"><%= @business.name %></p>
+    <p><span class="fw-bold"><%= @business.created_at.strftime("%b %Y") %></span></p>
+    <p><%= @business.description %></p>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="row" style="height: 250px;">
+    <% @business.collections.each do |collection| %>
+      <div class="row row-cols-1 row-cols-md-2 g-4 h-100">
+        <div class="col">
+          <div class="">
+            <img src="<%= cl_image_path collection.banner.key %>" class="card-img-top" alt="...">
+            <div class="">
+              <h5 class="">Card title</h5>
+              <p class="">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+<div class="wrapper">
+  <p class="fs-5 fw-bold mb-3 mt-3"><%= @business.tokens.count %> items</p>
+  <div>
+    <div class="row" style="height: 200px;">
+      <% @business.tokens.each_with_index do |token, index| %>
+        <div class="col-12 col-sm-6 col-md-3 mb-4 ">
+          <div class="flip">
+            <div class="card front bg-white">
+              <img src="<%= cl_image_path token.photo.key %>" class="card-img-top" alt="">
+              <div class="card-body">
+                <p class="card-text fw-bold my-0 mb-1"><%= token.collection.name %> <span class="fw-bold">#<%= index + 1 %></span></p>
+                <p class="fw-bold fs-5 my-0">0.030 ETH</p>
+                <% if token.user %>
+                  <p class="text-muted">Owned by <%= token.user.username %></p>
+                <% end %>
+              </div>
+            </div>
+            <div class="back d-flex flex-column text-center">
+              <div class="p-3 my-auto">
+                <h2><%= token.collection.name %> <span class="fw-bold">#<%= index + 1 %></span></h2>
+                <p><%= token.collection.description %></p>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   namespace :biz do
-    resources :businesses, except: :show
+    resources :businesses
     resources :users, only: %i[show]
-
-    get 'me', to: 'businesses#me'
   end
 
   resources :businesses do


### PR DESCRIPTION
# Description
`​biz/businesses/me` breaks convention which irks Richard. 
Let's switch back to a regular restful ` businesses/:id` since it is not a security risk for a business to be able to view another business's profile.
​
Fixes # (issue)
​Reroute /me to /:id.

## Type of change
​
Please delete options that are not relevant.
​
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
