### PR TITLE
made buttons fill the width of the info window popup

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,12 +1,14 @@
 .btn-catch {
   border-radius: 8px;
   animation: glow 600ms infinite alternate;
+  box-sizing: border-box;
 }
 
 .btn-cannot {
   border: 1px solid #cccccc;
   border-radius: 8px;
   background-color: #cccccc;
+  box-sizing: border-box;
 }
 
 @keyframes glow {


### PR DESCRIPTION
# Description
​
Made buttons fill the width of the info window popup.
​
Fixes #134  (issue)
​
## Type of change
​
- [X] Bug fix (non-breaking change which fixes an issue)

​
# How Has This Been Tested?
​
<img width="389" alt="Screenshot 2023-03-29 at 4 18 34 PM" src="https://user-images.githubusercontent.com/105141510/228471523-9b636ae8-cf74-45a3-9faf-2e327f8b3aae.png">
- [X] Active Button


<img width="389" alt="Screenshot 2023-03-29 at 4 18 28 PM" src="https://user-images.githubusercontent.com/105141510/228471445-05022da2-62a9-429a-a96c-007fa11e6ce7.png">

- [X] Non-active Button

​
# Checklist:
​

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
